### PR TITLE
Tup build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,32 @@
+# Created by https://www.gitignore.io
+
+### C++ ###
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+*.bin

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@
 *.out
 *.app
 *.bin
+
+### Tup ###
+.tup

--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
-# estrutura_de_dados_one
-Organização de códigos na linguagem C++, criados para solucionar exercícios da disciplina Estrutura de Dados Básicos  1 no semestre 2015.1 na UFRN. 
+# Estrutura de Dados Básicos 1
+
+Organização de códigos na linguagem C++, criados para solucionar exercícios da disciplina Estrutura de Dados Básicos  1 no semestre 2015.1 na UFRN.
+
+## Dependências
+
+Antes de mais nada certifique-se de que os seguintes programas estejam instalados em seu ambiente de desenvolvimento:
+
+* g++
+* Git
+* [Tup](http://gittup.org/tup/index.html)
+
+
+## Compilando
+
+Para compilar todos os arquivos, execute, da raiz do porjeto, o comando:
+
+```
+$ tup upd
+```
+
+Ao fim da compilação, arquivos com a extensão `.bin` estarão disponíveis em seus correspondentes diretórios.

--- a/lista00/Tupfile
+++ b/lista00/Tupfile
@@ -1,0 +1,1 @@
+: foreach *.cpp |> g++ -Wall %f -o %o |> %B.bin


### PR DESCRIPTION
Este pr adiciona instruções de compilação e um `Tupfile` para utilização com o `build system` [Tup](http://gittup.org/tup/index.html). O arquivo `Tupfile` automatiza a compilação de todos os arquivos contidos no diretório `lista00`, gerando executáveis com a extensão `.bin`. Mais instruções de compilação estão disponíveis no `README.md`. :wink: 
